### PR TITLE
Move body styles as internal css can be viewed properly with github html preview

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,14 +1,3 @@
-* {
-	padding: 0px;
-	margin: 0px;
-}
-
-body {
-	background-image: url(../asset/Background.jpg);
-	background-repeat: repeat;
-}
-/* END OF BODY BACKGROUND */
-
 .photo-profile {
 	padding: 20px 0px;
 }

--- a/index.html
+++ b/index.html
@@ -12,6 +12,19 @@
 	<link href="https://fonts.googleapis.com/css?family=Orbitron:900" rel="stylesheet">
 <!--===============================================================================================-->
 
+<style>
+	/* BODY BACKGROUND */
+	* {
+		padding: 0px;
+		margin: 0px;
+	}
+
+	body {
+		background-image: url(./asset/Background.jpg);
+		background-repeat: repeat;
+	}
+	/* END OF BODY BACKGROUND */
+</style>
 </head>
 <body>
 	
@@ -43,7 +56,7 @@
 					<h2>Birthday :</h2>
 					<p>21 September 1999</p>
 					<h2>Religion :</h2>
-					<p>Chatolic</p>
+					<p>Catholic</p>
 				</div>
 				<div class="bio-left">
 					<h2>Number Phone :</h2>


### PR DESCRIPTION
Hello, @Martinus21 . Website-nya keren banget 👍 

Tadi saya coba buka lewat [sini](https://stackoverflow.com/a/15678466) buat _preview_-nya, ternyata nggak muncul _background_-nya, sementara beberapa tulisan berwarna putih. Begitu saya _clone_, ternyata nggak bermasalah; _background_-nya menggunakan _pattern_ gelap. Bisa jadi karena github HTML preview ada _bugs_ ketika generate eksternal css ke internal css, belum normalisasi direktori _resource_-nya (misalnya direktori gambar)

Biar sama-sama enak, mohon maaf saya pindahin _style_ di _tag_ body jadi internal css. Biar waktu koreksi tugas, nilai-nya @Martinus21 nggak berkurang karena nggak muncul background sementara beberapa teks menggunakan warna putih. Khawatirnya Mas Aldy ngiranya @Martinus21  nggak bisa munculin background.

Saya juga koreksi tulisan `chatolic` jadi `catholic`. Setelah saya telusuri di internet, katolik berasal dari kata `kata` dan `holos` dari bahasa Yunani.  Untuk menambah nilai, diseragamkan saja, mau pakai bahasa Indonesia semua atau bahasa Inggris. Istilah `slicing` lebih tepat ketika membuat website dari desain yang ada di photoshop daripada `silencing`.